### PR TITLE
Add minimal engine modules with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Finally Fixed Space Issue
-# Confirming final git setup
-# Finally fixing push issue
-# .netrc Fix Commit
-# SSH authentication confirmed working
+# ATI Oracle Engine
+
+This system runs secure, modular AI rotors with backup/restore, snapshot rotation, agent execution, and cloud sync. Agents: Arbiter, Father, Soap, Watson. See configs/ai_config.json for model connections.

--- a/agents/arbiter_phase.py
+++ b/agents/arbiter_phase.py
@@ -1,0 +1,2 @@
+def run_arbiter(x):
+    return "[Arbiter resolves] " + str(x)

--- a/agents/father_phase.py
+++ b/agents/father_phase.py
@@ -1,0 +1,2 @@
+def run_father(x):
+    return "[Father logic for] " + str(x)

--- a/agents/soap_phase.py
+++ b/agents/soap_phase.py
@@ -1,0 +1,2 @@
+def run_soap(x):
+    return "[Soap builds SOP] " + str(x)

--- a/agents/watson_phase.py
+++ b/agents/watson_phase.py
@@ -1,0 +1,2 @@
+def run_watson():
+    return "[Watson ready]"

--- a/core/codex_folder_creator.py
+++ b/core/codex_folder_creator.py
@@ -1,0 +1,15 @@
+import os
+
+def create_codex_structure(base_path):
+    folders = [
+        "agents",
+        "core",
+        "triggers",
+        "configs",
+        "secrets",
+        "outputs"
+    ]
+    for folder in folders:
+        path = os.path.join(base_path, folder)
+        os.makedirs(path, exist_ok=True)
+    return True

--- a/core/snapshot_rotator.py
+++ b/core/snapshot_rotator.py
@@ -1,0 +1,12 @@
+import shutil
+import time
+import os
+
+def rotate_snapshots(src_dir, dst_dir, max_versions=3):
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    new_snapshot = os.path.join(dst_dir, f"snapshot_{timestamp}.zip")
+    shutil.make_archive(new_snapshot.replace('.zip', ''), 'zip', src_dir)
+    versions = sorted([f for f in os.listdir(dst_dir) if f.startswith("snapshot_") and f.endswith(".zip")])
+    while len(versions) > max_versions:
+        os.remove(os.path.join(dst_dir, versions.pop(0)))
+    return new_snapshot

--- a/core/trigger_attention.py
+++ b/core/trigger_attention.py
@@ -1,0 +1,2 @@
+def trigger_attention():
+    print("[ATTENTION] Rotor initialization triggered.")

--- a/core/trigger_code_red.py
+++ b/core/trigger_code_red.py
@@ -1,0 +1,2 @@
+def trigger_code_red():
+    print("[CODE-RED] Backup/offload started.")

--- a/core/trigger_full_save.py
+++ b/core/trigger_full_save.py
@@ -1,0 +1,4 @@
+from core.snapshot_rotator import rotate_snapshots
+
+def trigger_full_save(src_dir, dst_dir):
+    return rotate_snapshots(src_dir, dst_dir)

--- a/core/trigger_rebuild_all.py
+++ b/core/trigger_rebuild_all.py
@@ -1,0 +1,2 @@
+def trigger_rebuild_all():
+    print("[REBUILD-ALL] System-wide rebuild initiated.")

--- a/core/trigger_rotate_mem.py
+++ b/core/trigger_rotate_mem.py
@@ -1,0 +1,2 @@
+def trigger_rotate_mem():
+    print("[ROTATE-MEM] Rotating system memory buffers.")

--- a/core/trigger_save_zip.py
+++ b/core/trigger_save_zip.py
@@ -1,0 +1,2 @@
+def trigger_save_zip():
+    print("[SAVE-ZIP] Saving project state as zip.")

--- a/core/trigger_spin_control.py
+++ b/core/trigger_spin_control.py
@@ -1,0 +1,2 @@
+def trigger_spin_control():
+    print("[SPIN-CONTROL] Rotor engine manual control engaged.")

--- a/core/trigger_spin_down.py
+++ b/core/trigger_spin_down.py
@@ -1,0 +1,2 @@
+def trigger_spin_down():
+    print("[SPIN-DOWN] Safe shutdown initiated.")

--- a/core/trigger_spin_reset.py
+++ b/core/trigger_spin_reset.py
@@ -1,0 +1,2 @@
+def trigger_spin_reset():
+    print("[SPIN-RESET] System reset triggered.")

--- a/core/trigger_spin_up.py
+++ b/core/trigger_spin_up.py
@@ -1,0 +1,2 @@
+def trigger_spin_up():
+    print("[SPIN-UP] System restore started.")

--- a/core/trigger_test_harness.py
+++ b/core/trigger_test_harness.py
@@ -1,0 +1,2 @@
+def trigger_test_harness():
+    print("[TEST-HARNESS] Running system tests.")

--- a/spin_down.py
+++ b/spin_down.py
@@ -1,0 +1,13 @@
+import os
+import zipfile
+import time
+
+def spin_down(folder, out_zip):
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    zip_name = f"{out_zip}_{ts}.zip"
+    with zipfile.ZipFile(zip_name, 'w') as z:
+        for root, dirs, files in os.walk(folder):
+            for f in files:
+                path = os.path.join(root, f)
+                z.write(path, os.path.relpath(path, folder))
+    print(f"[SPIN-DOWN] Saved snapshot to {zip_name}")

--- a/spin_up.py
+++ b/spin_up.py
@@ -1,0 +1,7 @@
+import os
+import zipfile
+
+def spin_up(zip_path, extract_to):
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        zip_ref.extractall(extract_to)
+    print(f"[SPIN-UP] Restored from {zip_path}")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+import agents.arbiter_phase as arbiter
+import agents.father_phase as father
+import agents.soap_phase as soap
+import agents.watson_phase as watson
+
+
+def test_run_arbiter():
+    assert arbiter.run_arbiter('issue') == '[Arbiter resolves] issue'
+
+
+def test_run_father():
+    assert father.run_father('data') == '[Father logic for] data'
+
+
+def test_run_soap():
+    assert soap.run_soap('plan') == '[Soap builds SOP] plan'
+
+
+def test_run_watson():
+    assert watson.run_watson() == '[Watson ready]'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+import zipfile
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from core.codex_folder_creator import create_codex_structure
+from core.snapshot_rotator import rotate_snapshots
+
+
+def test_create_codex_structure(tmp_path):
+    base = tmp_path / 'codex'
+    create_codex_structure(base)
+    for folder in ['agents', 'core', 'triggers', 'configs', 'secrets', 'outputs']:
+        assert (base / folder).exists()
+
+
+def test_rotate_snapshots(tmp_path):
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    src.mkdir()
+    dst.mkdir()
+    # create a file in src
+    file_path = src / 'file.txt'
+    file_path.write_text('data')
+
+    snap1 = rotate_snapshots(src, dst, max_versions=2)
+    assert os.path.isfile(snap1)
+    # create another file to change snapshot content
+    file_path.write_text('new')
+    import time
+    time.sleep(1)
+    snap2 = rotate_snapshots(src, dst, max_versions=2)
+    assert os.path.isfile(snap2)
+    # create third snapshot to trigger rotation
+    file_path.write_text('more')
+    time.sleep(1)
+    snap3 = rotate_snapshots(src, dst, max_versions=2)
+    assert os.path.isfile(snap3)
+    snaps = sorted(p for p in os.listdir(dst) if p.startswith('snapshot_'))
+    assert len(snaps) == 2


### PR DESCRIPTION
## Summary
- initialize simple agent and core modules
- implement snapshot rotation and codex folder utilities
- add spin up/down helpers
- provide numerous trigger functions
- add unit tests for the modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877111786788324861d20a650438e77