### PR TITLE
Refactor path handling via common helper

### DIFF
--- a/Soap/agents/arbiter_phase.py
+++ b/Soap/agents/arbiter_phase.py
@@ -7,10 +7,12 @@ import json
 import logging
 from pathlib import Path
 
+from Soap.utils import get_soap_root
+
 # Configuration
-HOME_DIR = Path.home()
-QUEUE_DIR = HOME_DIR / "Soap" / "agent_queue"
-LOG_DIR = HOME_DIR / "Soap" / "data" / "logs"
+ROOT = get_soap_root()
+QUEUE_DIR = ROOT / "agent_queue"
+LOG_DIR = ROOT / "data" / "logs"
 LOG_FILE = LOG_DIR / "arbiter_phase.log"
 
 # Setup logging

--- a/Soap/agents/father_phase.py
+++ b/Soap/agents/father_phase.py
@@ -7,10 +7,12 @@ import json
 import logging
 from pathlib import Path
 
+from Soap.utils import get_soap_root
+
 # Configuration
-HOME_DIR = Path.home()
-QUEUE_DIR = HOME_DIR / "Soap" / "agent_queue"
-LOG_DIR = HOME_DIR / "Soap" / "data" / "logs"
+ROOT = get_soap_root()
+QUEUE_DIR = ROOT / "agent_queue"
+LOG_DIR = ROOT / "data" / "logs"
 LOG_FILE = LOG_DIR / "father_phase.log"
 
 # Setup logging

--- a/Soap/agents/soap_phase.py
+++ b/Soap/agents/soap_phase.py
@@ -7,10 +7,12 @@ import json
 import logging
 from pathlib import Path
 
+from Soap.utils import get_soap_root
+
 # Configuration
-HOME_DIR = Path.home()
-QUEUE_DIR = HOME_DIR / "Soap" / "agent_queue"
-LOG_DIR = HOME_DIR / "Soap" / "data" / "logs"
+ROOT = get_soap_root()
+QUEUE_DIR = ROOT / "agent_queue"
+LOG_DIR = ROOT / "data" / "logs"
 LOG_FILE = LOG_DIR / "soap_phase.log"
 
 # Setup logging

--- a/Soap/agents/watson_phase.py
+++ b/Soap/agents/watson_phase.py
@@ -7,10 +7,12 @@ import json
 import logging
 from pathlib import Path
 
+from Soap.utils import get_soap_root
+
 # Configuration
-HOME_DIR = Path.home()
-QUEUE_DIR = HOME_DIR / "Soap" / "agent_queue"
-LOG_DIR = HOME_DIR / "Soap" / "data" / "logs"
+ROOT = get_soap_root()
+QUEUE_DIR = ROOT / "agent_queue"
+LOG_DIR = ROOT / "data" / "logs"
 LOG_FILE = LOG_DIR / "watson_phase.log"
 
 # Setup logging

--- a/Soap/core/codex_folder_creator.py
+++ b/Soap/core/codex_folder_creator.py
@@ -8,7 +8,9 @@ from pathlib import Path
 import json
 from datetime import datetime
 
-ROOT = Path.home() / "Soap"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
 SNAPSHOT_AGENTS = ["watson", "father", "arbiter", "soap", "streamkeeper", "healer"]
 LOG_PATH = ROOT / "logs" / "codex_init.log"
 MANIFEST_PATH = ROOT / "overlay" / "manifest.json"

--- a/Soap/utils.py
+++ b/Soap/utils.py
@@ -1,0 +1,8 @@
+import os
+from pathlib import Path
+
+
+def get_soap_root() -> Path:
+    """Return the Soap root directory honoring $SOAP_ROOT."""
+    env = os.getenv("SOAP_ROOT")
+    return Path(env).expanduser() if env else Path.home() / "Soap"

--- a/agent_lock_checker.py
+++ b/agent_lock_checker.py
@@ -3,8 +3,9 @@
 import hashlib
 import json
 import logging
-import os
 from pathlib import Path
+
+from Soap.utils import get_soap_root
 
 AGENTS = [
     "watson_phase.py",
@@ -13,11 +14,6 @@ AGENTS = [
     "arbiter_phase.py",
     "soap_phase.py",
 ]
-
-
-def get_soap_root() -> Path:
-    env = os.getenv("SOAP_ROOT")
-    return Path(env).expanduser() if env else Path.home() / "Soap"
 
 
 def load_reference(root: Path) -> dict:

--- a/agents/arbiter_phase.py
+++ b/agents/arbiter_phase.py
@@ -9,9 +9,11 @@ import json
 import logging
 from pathlib import Path
 
-HOME_DIR = Path.home()
-QUEUE_DIR = HOME_DIR / "Soap" / "agent_queue"
-LOG_DIR = HOME_DIR / "Soap" / "data" / "logs"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+QUEUE_DIR = ROOT / "agent_queue"
+LOG_DIR = ROOT / "data" / "logs"
 LOG_FILE = LOG_DIR / "arbiter_phase.log"
 
 LOG_DIR.mkdir(parents=True, exist_ok=True)

--- a/agents/father_phase.py
+++ b/agents/father_phase.py
@@ -9,9 +9,11 @@ import json
 import logging
 from pathlib import Path
 
-HOME_DIR = Path.home()
-QUEUE_DIR = HOME_DIR / "Soap" / "agent_queue"
-LOG_DIR = HOME_DIR / "Soap" / "data" / "logs"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+QUEUE_DIR = ROOT / "agent_queue"
+LOG_DIR = ROOT / "data" / "logs"
 LOG_FILE = LOG_DIR / "father_phase.log"
 
 LOG_DIR.mkdir(parents=True, exist_ok=True)

--- a/agents/mother_phase.py
+++ b/agents/mother_phase.py
@@ -7,12 +7,14 @@ import json
 import logging
 from pathlib import Path
 
+from Soap.utils import get_soap_root
+
 # Configuration
-HOME_DIR = Path.home()
-QUEUE_DIR = HOME_DIR / "Soap" / "agent_queue"
-LOG_DIR = HOME_DIR / "Soap" / "data" / "logs"
+ROOT = get_soap_root()
+QUEUE_DIR = ROOT / "agent_queue"
+LOG_DIR = ROOT / "data" / "logs"
 LOG_FILE = LOG_DIR / "mother_phase.log"
-RULES_FILE = HOME_DIR / "Soap" / "overlay" / "regulatory_rules.json"
+RULES_FILE = ROOT / "overlay" / "regulatory_rules.json"
 
 # Default safety rules
 PPE_DEFAULTS = [

--- a/agents/soap_phase.py
+++ b/agents/soap_phase.py
@@ -9,9 +9,11 @@ import json
 import logging
 from pathlib import Path
 
-HOME_DIR = Path.home()
-QUEUE_DIR = HOME_DIR / "Soap" / "agent_queue"
-LOG_DIR = HOME_DIR / "Soap" / "data" / "logs"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+QUEUE_DIR = ROOT / "agent_queue"
+LOG_DIR = ROOT / "data" / "logs"
 LOG_FILE = LOG_DIR / "soap_phase.log"
 
 def setup_logging():

--- a/agents/watson_phase.py
+++ b/agents/watson_phase.py
@@ -9,9 +9,11 @@ import json
 import logging
 from pathlib import Path
 
-HOME_DIR = Path.home()
-QUEUE_DIR = HOME_DIR / "Soap" / "agent_queue"
-LOG_DIR = HOME_DIR / "Soap" / "data" / "logs"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+QUEUE_DIR = ROOT / "agent_queue"
+LOG_DIR = ROOT / "data" / "logs"
 LOG_FILE = LOG_DIR / "watson_phase.log"
 
 LOG_DIR.mkdir(parents=True, exist_ok=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import json
 import time
 
-from codex_controller import process_queue, get_soap_root
+from codex_controller import process_queue
+from Soap.utils import get_soap_root
 
 app = FastAPI(title="ATI Oracle Backend")
 

--- a/backup_now.py
+++ b/backup_now.py
@@ -11,11 +11,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-
-def get_soap_root() -> Path:
-    """Return the Soap root directory."""
-    env_path = os.getenv("SOAP_ROOT")
-    return Path(env_path).expanduser() if env_path else Path.home() / "Soap"
+from Soap.utils import get_soap_root
 
 
 def setup_logger() -> logging.Logger:

--- a/codex_controller.py
+++ b/codex_controller.py
@@ -7,7 +7,6 @@ them through all five agents in sequence. Completed SOPs are exported to
 """
 import argparse
 import json
-import os
 import time
 from pathlib import Path
 
@@ -19,11 +18,7 @@ from agents.soap_phase import run_soap
 from warm_start_engine import load_vectors, search_similar
 from rag_vectorizer import vectorize
 
-
-def get_soap_root() -> Path:
-    """Return the Soap root directory, honoring $SOAP_ROOT."""
-    env = os.getenv("SOAP_ROOT")
-    return Path(env).expanduser() if env else Path.home() / "Soap"
+from Soap.utils import get_soap_root
 
 
 def attach_related_sops(queue_dir: Path) -> None:

--- a/rag_vectorizer.py
+++ b/rag_vectorizer.py
@@ -6,13 +6,13 @@ import os
 from pathlib import Path
 from typing import List
 
+from Soap.utils import get_soap_root
+
 import joblib
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 
-HOME_DIR = Path.home()
-SOAP_ROOT_ENV = os.getenv("SOAP_ROOT")
-SOAP_ROOT = Path(SOAP_ROOT_ENV).expanduser() if SOAP_ROOT_ENV else HOME_DIR / "Soap"
+SOAP_ROOT = get_soap_root()
 
 VECTOR_DIR = SOAP_ROOT / "vector_store"
 SOPS_DIR = SOAP_ROOT / "overlay" / "sops"

--- a/rebuild_watcher.py
+++ b/rebuild_watcher.py
@@ -4,8 +4,11 @@ import time
 from pathlib import Path
 import subprocess
 
-FLAG = Path.home() / "Soap/.trigger.rebuild"
-TRIGGER = Path.home() / "Soap/restore_now.py"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+FLAG = ROOT / ".trigger.rebuild"
+TRIGGER = ROOT / "restore_now.py"
 
 
 def main() -> None:

--- a/restore_now.py
+++ b/restore_now.py
@@ -6,10 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-
-def get_soap_root() -> Path:
-    env_path = os.getenv("SOAP_ROOT")
-    return Path(env_path).expanduser() if env_path else Path.home() / "Soap"
+from Soap.utils import get_soap_root
 
 
 def setup_logger() -> logging.Logger:

--- a/system_snapshot.py
+++ b/system_snapshot.py
@@ -1,12 +1,7 @@
-import os
 from pathlib import Path
 
 from core.snapshot_rotator import rotate_snapshots
-
-
-def get_soap_root() -> Path:
-    env = os.getenv("SOAP_ROOT")
-    return Path(env).expanduser() if env else Path.home() / "Soap"
+from Soap.utils import get_soap_root
 
 
 def create_snapshot(dst: Path | None = None) -> Path:

--- a/trigger_attention.py
+++ b/trigger_attention.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_attention.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_attention.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,9 +19,9 @@ def log(msg):
 def main():
     print("🧠 [+ATTENTION+] SYSTEM IS WAKING UP...")
     log("Attention trigger fired.")
-    subprocess.run("python3 ~/Soap/attention.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/attention.py", shell=True)
     print("🔁 Handing off to ROTOR_FUSION...")
-    subprocess.run("python3 ~/Soap/rotor_fusion.py +CODE-RED+", shell=True)
+    subprocess.run(f"python3 {ROOT}/rotor_fusion.py +CODE-RED+", shell=True)
 
 
 if __name__ == "__main__":

--- a/trigger_boot.py
+++ b/trigger_boot.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_boot.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_boot.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,7 +19,7 @@ def log(msg: str) -> None:
 def main() -> None:
     print("🚀 [+BOOT+] Starting full start sequence...")
     log("BOOT trigger fired")
-    root = Path.home() / "Soap/triggers"
+    root = ROOT / "triggers"
     for trig in ["+ATTENTION+", "+CODE-RED+", "+SPIN-UP+"]:
         subprocess.run(["bash", str(root / trig)], check=False)
     log("BOOT sequence completed")

--- a/trigger_code_red.py
+++ b/trigger_code_red.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_code_red.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_code_red.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,7 +19,7 @@ def log(msg: str) -> None:
 def main() -> None:
     print("🔥 [+CODE-RED+] Uploading and purging bloat...")
     log("Code-Red trigger fired")
-    subprocess.run("python3 ~/Soap/code_red.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/code_red.py", shell=True)
     log("Code-Red complete")
 
 

--- a/trigger_full_save.py
+++ b/trigger_full_save.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_full_save.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_full_save.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,7 +19,7 @@ def log(msg: str) -> None:
 def main() -> None:
     print("💾 [+FULL-SAVE+] Zipping and uploading Soap...")
     log("Full save trigger fired")
-    subprocess.run("python3 ~/Soap/full_save.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/full_save.py", shell=True)
     log("Full save complete")
 
 

--- a/trigger_full_save_now.py
+++ b/trigger_full_save_now.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_full_save_now.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_full_save_now.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,7 +19,7 @@ def log(msg: str) -> None:
 def main() -> None:
     print("💾 [+FULL_SAVE_NOW+] Saving system state now...")
     log("Full save now trigger fired")
-    subprocess.run("python3 ~/Soap/full_save_now.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/full_save_now.py", shell=True)
     log("Full save now complete")
 
 

--- a/trigger_rebuild_all.py
+++ b/trigger_rebuild_all.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_rebuild_all.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_rebuild_all.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,7 +19,7 @@ def log(msg: str) -> None:
 def main() -> None:
     print("🔨 [+REBUILD-ALL+] Restoring protected files from registry...")
     log("Rebuild-all trigger fired")
-    subprocess.run("python3 ~/Soap/rebuild_all.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/rebuild_all.py", shell=True)
     log("Rebuild-all complete")
 
 

--- a/trigger_rotate_mem.py
+++ b/trigger_rotate_mem.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_rotate_mem.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_rotate_mem.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,7 +19,7 @@ def log(msg: str) -> None:
 def main() -> None:
     print("🔁 [+ROTATE-MEM+] Playing zip logs...")
     log("Rotate-mem trigger fired")
-    subprocess.run("python3 ~/Soap/rotate_mem.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/rotate_mem.py", shell=True)
     log("Rotate-mem complete")
 
 

--- a/trigger_save_zip.py
+++ b/trigger_save_zip.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_save_zip.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_save_zip.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,7 +19,7 @@ def log(msg: str) -> None:
 def main() -> None:
     print("📦 [+SAVE-ZIP+] Zipping Soap directory locally...")
     log("Save-zip trigger fired")
-    subprocess.run("python3 ~/Soap/save_zip.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/save_zip.py", shell=True)
     log("Save-zip complete")
 
 

--- a/trigger_spin_control.py
+++ b/trigger_spin_control.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_spin_control.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_spin_control.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,7 +19,7 @@ def log(msg: str) -> None:
 def main() -> None:
     print("⚙️ [+SPIN-CONTROL+] Checking critical directories...")
     log("Spin-control trigger fired")
-    subprocess.run("python3 ~/Soap/spin_control.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/spin_control.py", shell=True)
     log("Spin-control complete")
 
 

--- a/trigger_spin_down.py
+++ b/trigger_spin_down.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_spin_down.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_spin_down.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -19,7 +22,7 @@ def main():
         "rotors..."
     )
     log("Spin-Down initiated from trigger.")
-    subprocess.run("python3 ~/Soap/spin_down.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/spin_down.py", shell=True)
     print("💤 [SPIN-DOWN] Rotor engine is offline.")
     log("Spin-Down complete.")
 

--- a/trigger_spin_reset.py
+++ b/trigger_spin_reset.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_spin_reset.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_spin_reset.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,7 +19,7 @@ def log(msg: str) -> None:
 def main() -> None:
     print("♻️ [+SPIN-RESET+] Purging temp files and caches...")
     log("Spin-reset trigger fired")
-    subprocess.run("python3 ~/Soap/spin_reset.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/spin_reset.py", shell=True)
     log("Spin-reset complete")
 
 

--- a/trigger_spin_up.py
+++ b/trigger_spin_up.py
@@ -4,7 +4,10 @@ import subprocess
 from pathlib import Path
 import time
 
-LOG_PATH = Path.home() / "Soap/logs/trigger_spin_up.log"
+from Soap.utils import get_soap_root
+
+ROOT = get_soap_root()
+LOG_PATH = ROOT / "logs/trigger_spin_up.log"
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
@@ -16,7 +19,7 @@ def log(msg: str) -> None:
 def main() -> None:
     print("🔄 [+SPIN-UP+] Restoring from cloud and relaunching rotors...")
     log("Spin-Up trigger fired")
-    subprocess.run("python3 ~/Soap/spin_up.py", shell=True)
+    subprocess.run(f"python3 {ROOT}/spin_up.py", shell=True)
     log("Spin-Up complete")
 
 

--- a/trigger_test_harness.py
+++ b/trigger_test_harness.py
@@ -3,6 +3,8 @@
 import subprocess
 from pathlib import Path
 
+from Soap.utils import get_soap_root
+
 TRIGGERS = [
     "+ATTENTION+",
     "+CODE-RED+",
@@ -13,7 +15,7 @@ TRIGGERS = [
 
 
 def main() -> None:
-    root = Path.home() / "Soap/triggers"
+    root = get_soap_root() / "triggers"
     for trig in TRIGGERS:
         path = root / trig
         print(f"⚡ Running {trig} ...")

--- a/warm_start_engine.py
+++ b/warm_start_engine.py
@@ -5,13 +5,13 @@ import logging
 import os
 from pathlib import Path
 
+from Soap.utils import get_soap_root
+
 import joblib
 from scipy import sparse
 from sklearn.metrics.pairwise import cosine_similarity
 
-HOME_DIR = Path.home()
-SOAP_ROOT_ENV = os.getenv("SOAP_ROOT")
-SOAP_ROOT = Path(SOAP_ROOT_ENV).expanduser() if SOAP_ROOT_ENV else HOME_DIR / "Soap"
+SOAP_ROOT = get_soap_root()
 ROOT = SOAP_ROOT
 VECTOR_DIR = ROOT / "vector_store"
 LOG_FILE = ROOT / "data" / "logs" / "warm_start_engine.log"


### PR DESCRIPTION
## Summary
- create `Soap.utils.get_soap_root`
- switch agents and utilities to use the helper instead of `Path.home()/"Soap"`
- adjust triggers and backend to import the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884dae0232c83249c213b6866f53006