### PR TITLE
Add install_and_boot script

### DIFF
--- a/install_and_boot.sh
+++ b/install_and_boot.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Install dependencies and start Codex engine
+# If .venv already exists, reuse it
+
+set -e
+
+ROOT="${SOAP_ROOT:-$HOME/Soap}"
+VENV="$ROOT/.venv"
+
+if [ ! -d "$VENV" ]; then
+    echo "Creating virtual environment at $VENV"
+    python3 -m venv "$VENV"
+    "$VENV/bin/pip" install --upgrade pip
+    "$VENV/bin/pip" install -r "$ROOT/requirements.txt"
+fi
+
+source "$VENV/bin/activate"
+
+exec "$VENV/bin/python" "$ROOT/codex_controller.py" --loop --warm-start

--- a/trigger_spin_up.py
+++ b/trigger_spin_up.py
@@ -16,7 +16,8 @@ def log(msg: str) -> None:
 def main() -> None:
     print("🔄 [+SPIN-UP+] Restoring from cloud and relaunching rotors...")
     log("Spin-Up trigger fired")
-    subprocess.run("python3 ~/Soap/spin_up.py", shell=True)
+    script = Path.home() / "Soap/install_and_boot.sh"
+    subprocess.run(["bash", str(script)], check=False)
     log("Spin-Up complete")
 
 


### PR DESCRIPTION
## Summary
- add a reusable `install_and_boot.sh` script
- update spin-up trigger to call the new script

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688409da027083248af84275dd395aa0