### PR TITLE
feat: add specialized Ollama agent

### DIFF
--- a/backend/configs/ai_config.json
+++ b/backend/configs/ai_config.json
@@ -1,0 +1,16 @@
+{
+  "general": {
+    "ollama_host": "http://localhost:11434"
+  },
+  "models": {
+    "ollama_mistral_7b": {
+      "provider": "ollama",
+      "name": "mistral:latest",
+      "enabled": true,
+      "parameters": {
+        "temperature": 0.7,
+        "max_tokens": 1024
+      }
+    }
+  }
+}

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,5 @@
+from .config_loader import AIModelConfig, ConfigLoader
+from .ollama_agent import OllamaAgent
+from .ollama_client import OllamaClient
+
+__all__ = ["AIModelConfig", "ConfigLoader", "OllamaAgent", "OllamaClient"]

--- a/backend/services/config_loader.py
+++ b/backend/services/config_loader.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+
+@dataclass
+class AIModelConfig:
+    provider: str
+    name: str
+    enabled: bool = True
+    parameters: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AIConfig:
+    general: Dict[str, Any] = field(default_factory=dict)
+    models: Dict[str, AIModelConfig] = field(default_factory=dict)
+
+
+class ConfigLoader:
+    """Load AI configuration from a JSON file."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        if path is None:
+            path = Path(__file__).resolve().parents[1] / "configs" / "ai_config.json"
+        self.path = path
+        self._config: AIConfig | None = None
+
+    def get_config(self) -> AIConfig:
+        if self._config is None:
+            data = json.loads(self.path.read_text())
+            general = data.get("general", {})
+            models = {
+                key: AIModelConfig(**val) for key, val in data.get("models", {}).items()
+            }
+            self._config = AIConfig(general=general, models=models)
+        return self._config

--- a/backend/services/ollama_agent.py
+++ b/backend/services/ollama_agent.py
@@ -1,0 +1,33 @@
+import logging
+from typing import Optional
+
+from .ollama_client import OllamaClient
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaAgent:
+    """Specialized agent using :class:`OllamaClient` as its toolbox."""
+
+    def __init__(self, client: OllamaClient) -> None:
+        self.client = client
+
+    async def ensure_ready(self) -> bool:
+        """Verify the underlying Ollama service is reachable."""
+        return await self.client.ensure_ready()
+
+    async def run(
+        self, prompt: str, model_id: str = "ollama_mistral_7b", **kwargs
+    ) -> Optional[str]:
+        """Generate text via the managed :class:`OllamaClient`.
+
+        Args:
+            prompt: The text prompt to send.
+            model_id: Identifier of the configured Ollama model.
+            **kwargs: Extra generation parameters.
+        """
+        return await self.client.generate_text(model_id=model_id, prompt=prompt, **kwargs)
+
+    async def close(self) -> None:
+        """Release resources held by the underlying client."""
+        await self.client.close()

--- a/backend/services/ollama_client.py
+++ b/backend/services/ollama_client.py
@@ -1,0 +1,144 @@
+import logging
+from typing import Dict, Optional
+
+import httpx
+from httpx import AsyncClient, HTTPStatusError, RequestError, TimeoutException
+
+from .config_loader import ConfigLoader, AIModelConfig
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaClient:
+    """Service for interacting with a locally running Ollama instance.
+    Manages text generation requests to local LLMs."""
+
+    def __init__(self, config_loader: ConfigLoader):
+        self.config_loader = config_loader
+        self.config = self.config_loader.get_config()
+        self.ollama_host = self.config.general.get("ollama_host")
+        self.http_client: Optional[AsyncClient] = None
+        if not self.ollama_host:
+            logger.error(
+                "Ollama host not configured in ai_config.json -> general.ollama_host."
+            )
+            self.is_ready = False
+        else:
+            self.http_client = AsyncClient(base_url=self.ollama_host, timeout=30.0)
+            self.is_ready = True
+            logger.info(
+                f"OllamaClient initialized, targeting host: {self.ollama_host}"
+            )
+
+    async def close(self) -> None:
+        """Close underlying HTTP client."""
+        if self.http_client:
+            await self.http_client.aclose()
+
+    async def _check_ollama_status(self) -> bool:
+        """Checks if the Ollama server is reachable."""
+        if not self.is_ready or not self.http_client:
+            return False
+        try:
+            response = await self.http_client.get("/api/tags")
+            response.raise_for_status()
+            logger.debug("Ollama server is reachable.")
+            return True
+        except HTTPStatusError as e:
+            logger.warning(
+                f"Ollama server returned an error status: {e.response.status_code} - {e.response.text}"
+            )
+            return False
+        except RequestError as e:
+            logger.warning(
+                f"Could not connect to Ollama server at {self.ollama_host}: {e}"
+            )
+            self.is_ready = False
+            return False
+        except Exception as e:
+            logger.exception(
+                f"An unexpected error occurred while checking Ollama status: {e}"
+            )
+            return False
+
+    async def ensure_ready(self) -> bool:
+        """Public helper to verify the Ollama server is reachable."""
+        if not self.is_ready:
+            return False
+        return await self._check_ollama_status()
+
+    async def generate_text(self, model_id: str, prompt: str, **kwargs) -> Optional[str]:
+        """Generates text using a specified local Ollama model."""
+        if not await self.ensure_ready():
+            logger.error(
+                f"Ollama client not ready or server unreachable for model: {model_id}"
+            )
+            return None
+
+        model_cfg: Optional[AIModelConfig] = self.config.models.get(model_id)
+        if (
+            not model_cfg
+            or not model_cfg.enabled
+            or model_cfg.provider != "ollama"
+        ):
+            logger.warning(
+                f"Attempted to use disabled, non-existent, or non Ollama model: {model_id}"
+            )
+            return None
+
+        ollama_model_name = model_cfg.name
+
+        default_params: Dict[str, float] = {}
+        if getattr(model_cfg, "parameters", None):
+            try:
+                default_params = model_cfg.parameters.dict(exclude_none=True)
+            except AttributeError:
+                if isinstance(model_cfg.parameters, dict):
+                    default_params = {
+                        k: v for k, v in model_cfg.parameters.items() if v is not None
+                    }
+
+        params = {**default_params, **kwargs}
+        request_body = {
+            "model": ollama_model_name,
+            "prompt": prompt,
+            "stream": False,
+            "options": {
+                "temperature": params.get("temperature", 0.7),
+                "num_predict": params.get("max_tokens", 1024),
+            },
+        }
+
+        if not self.http_client:
+            logger.error("HTTP client not initialized.")
+            return None
+
+        try:
+            response = await self.http_client.post(
+                "/api/generate", json=request_body
+            )
+            response.raise_for_status()
+            data = response.json()
+            generated_text = data.get("response", "").strip()
+            logger.debug(
+                f"Ollama generated text for {model_id}, length: {len(generated_text)}"
+            )
+            return generated_text
+        except HTTPStatusError as e:
+            logger.error(
+                f"Ollama API call for {model_id} failed with status {e.response.status_code}: {e.response.text}"
+            )
+            return None
+        except TimeoutException as e:
+            logger.error(f"Ollama API call for {model_id} timed out: {e}")
+            return None
+        except RequestError as e:
+            logger.error(
+                f"Network error during Ollama API call for {model_id}: {e}"
+            )
+            return None
+        except Exception as e:
+            logger.exception(
+                f"An unexpected error occurred during Ollama text generation for {model_id}."
+            )
+            return None

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,0 +1,40 @@
+import asyncio
+import json
+import httpx
+
+from backend.services import ConfigLoader, OllamaClient
+
+
+def test_generate_text(tmp_path):
+    async def run():
+        config = {
+            "general": {"ollama_host": "http://test"},
+            "models": {
+                "ollama_mistral_7b": {
+                    "provider": "ollama",
+                    "name": "mistral:latest",
+                    "enabled": True,
+                    "parameters": {"temperature": 0.7, "max_tokens": 100},
+                }
+            },
+        }
+        config_path = tmp_path / "ai_config.json"
+        config_path.write_text(json.dumps(config))
+        loader = ConfigLoader(config_path)
+
+        async def handler(request):
+            if request.url.path == "/api/tags":
+                return httpx.Response(200, json={})
+            if request.url.path == "/api/generate":
+                return httpx.Response(200, json={"response": "hello"})
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        client = OllamaClient(loader)
+        client.http_client = httpx.AsyncClient(transport=transport, base_url="http://test")
+        assert await client.ensure_ready() is True
+        text = await client.generate_text("ollama_mistral_7b", "hi")
+        assert text == "hello"
+        await client.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- expose readiness check in Ollama client for agent use
- implement dedicated agent leveraging Ollama client as toolbox
- introduce dataclass-based config loader with default AI model settings
- cover Ollama client interactions with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d3ff1b7148324bc3c1ad996f13a9b